### PR TITLE
chore(security): add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+version: 2
+
+# LikenessGuard ships three package surfaces:
+#   - pip:    likenessguard-aws/requirements-dev.txt (test deps)
+#   - npm:    likenessguard-dashboard/ (React app)
+#   - github-actions: .github/workflows/* (CI pinning)
+#
+# Issue #9 asks for weekly updates with minor/patch grouping so we
+# don't drown in PR noise on small bumps. Major bumps still get
+# their own PR so reviewers can read the changelog before merging.
+
+updates:
+  # Python — likenessguard-aws test/runtime dependencies
+  - package-ecosystem: "pip"
+    directory: "/likenessguard-aws"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # JavaScript / TypeScript — React dashboard
+  - package-ecosystem: "npm"
+    directory: "/likenessguard-dashboard"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "javascript"
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used by ci.yml / security-scan.yml. SHA-pinned
+  # actions still get version-comment updates from Dependabot here.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Closes #9.

Add \`.github/dependabot.yml\` covering the three package surfaces
LikenessGuard actually ships:

- **pip** — \`likenessguard-aws/requirements-dev.txt\`
- **npm** — \`likenessguard-dashboard/\` (React app, has
  \`package.json\` + \`package-lock.json\`)
- **github-actions** — workflows under \`.github/workflows/\`
  (\`ci.yml\`, \`security-scan.yml\`)

The Python SDK (\`likenessguard-aws/sdk/python/\`) and Node SDK
(\`likenessguard-aws/sdk/nodejs/\`) don't have package manifests of
their own yet (no \`pyproject.toml\` / \`package.json\` at those
roots), so they're intentionally not listed; they can be added in a
follow-up once they ship as installable packages.

## Layout

Each ecosystem:

- Runs **weekly**.
- Groups minor/patch updates into a single PR
  (\`<ecosystem>-minor-and-patch\`) so reviewers don't have to
  triage one PR per dependency. Majors still surface as individual
  PRs so the changelog gets read before merging.
- Caps the open-PR queue at \`open-pull-requests-limit: 5\`.
- Carries a \`dependencies\` label plus an ecosystem-specific tag
  (\`python\`, \`javascript\`, \`github-actions\`) for filtering.

## Test plan

- [x] YAML parsed cleanly with
      \`python3 -c \"import yaml; yaml.safe_load(open('.github/dependabot.yml'))\"\`.
- [x] Manifests at every \`directory:\` exist on \`main\`
      (\`likenessguard-aws/requirements-dev.txt\`,
      \`likenessguard-dashboard/package.json\`).
- [ ] Live behaviour will be confirmed when GitHub picks up the
      file on merge — Dependabot validates the schema server-side
      and surfaces any issues in the repo's
      \`Insights → Dependency graph → Dependabot\` page.

Commit is DCO-signed per CONTRIBUTING.md.